### PR TITLE
Mild refactor of time sources processing

### DIFF
--- a/tests/data/chronyconfs/4_chrony.conf
+++ b/tests/data/chronyconfs/4_chrony.conf
@@ -1,0 +1,49 @@
+# This file was converted from tests/data/ntpconfs/4_ntp.conf.
+
+# Specify time sources.
+pool 2.pool.ntp.org
+pool 2.rhel.pool.ntp.org
+server 42.rhel.pool.ntp.org
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access.
+allow 0.0.0.0/0
+allow 127.0.0.1
+allow ::/0
+
+# Allow remote monitoring.
+cmdallow 0.0.0.0/0
+cmdallow ::/0
+bindcmdaddress 0.0.0.0
+bindcmdaddress ::
+
+# Serve time even if not synchronized to a time source.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+keyfile tests/data/chronyconfs/4_chrony.keys
+
+# Get TAI-UTC offset and leap seconds from the system tz database.
+leapsectz right/UTC
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/tests/data/chronyconfs/5_chrony.conf
+++ b/tests/data/chronyconfs/5_chrony.conf
@@ -1,0 +1,48 @@
+# This file was converted from tests/data/ntpconfs/5_ntp.conf.
+
+# Specify time sources.
+pool 2.pool.ntp.org
+peer 0.pool.ntp.org
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access.
+allow 0.0.0.0/0
+allow 127.0.0.1
+allow ::/0
+
+# Allow remote monitoring.
+cmdallow 0.0.0.0/0
+cmdallow ::/0
+bindcmdaddress 0.0.0.0
+bindcmdaddress ::
+
+# Serve time even if not synchronized to a time source.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+keyfile tests/data/chronyconfs/5_chrony.keys
+
+# Get TAI-UTC offset and leap seconds from the system tz database.
+leapsectz right/UTC
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/tests/data/ntpconfs/4_ntp.conf
+++ b/tests/data/ntpconfs/4_ntp.conf
@@ -1,0 +1,15 @@
+restrict 127.0.0.1
+restrict default kod nomodify notrap
+driftfile /var/lib/ntp/drift
+
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+server 0.pool.ntp.org
+server 1.pool.ntp.org
+server 2.pool.ntp.org
+server 3.pool.ntp.org
+server 0.rhel.pool.ntp.org
+server 1.rhel.pool.ntp.org
+server 2.rhel.pool.ntp.org
+server 3.rhel.pool.ntp.org
+server 42.rhel.pool.ntp.org

--- a/tests/data/ntpconfs/5_ntp.conf
+++ b/tests/data/ntpconfs/5_ntp.conf
@@ -1,0 +1,9 @@
+restrict 127.0.0.1
+restrict default kod nomodify notrap
+driftfile /var/lib/ntp/drift
+
+server 0.pool.ntp.org
+server 1.pool.ntp.org
+server 2.pool.ntp.org
+server 3.pool.ntp.org
+peer 0.pool.ntp.org


### PR DESCRIPTION
In case includefile directive was specified and
in an included config servers with the same name
were present this resulted in a duplicate pool servers
in chrony.conf.
Besides this patch addresses the issue with wrong
numbers of pool servers required for conversion
(NOT IMPLEMENTED YET, waiting for confirmation from mlichvar)

Some minor code refactor has also been done.